### PR TITLE
Move commands into functions

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -18,47 +18,59 @@ pub struct Cli {
     pub subcommand: Subcommand,
 }
 
+#[derive(StructOpt, Debug, PartialEq)]
+pub struct EncodeArgs {
+    #[structopt(parse(from_os_str), help = "Path to the input PNG")]
+    pub input_file_path: PathBuf,
+    #[structopt(
+            parse(try_from_str = ChunkType::from_str),
+            help = "Chunk type (like 'ruSt')"
+        )]
+    pub chunk_type: ChunkType,
+    #[structopt(help = "Your secret message")]
+    pub message: String,
+    #[structopt(parse(from_os_str), help = "Path to the output PNG (optional)")]
+    pub output_file_path: Option<PathBuf>,
+}
+
+#[derive(StructOpt, Debug, PartialEq)]
+pub struct DecodeArgs {
+    #[structopt(parse(from_os_str), help = "Path to the PNG")]
+    pub file_path: PathBuf,
+    #[structopt(
+            parse(try_from_str = ChunkType::from_str),
+            help = "Chunk type (like 'ruSt')"
+        )]
+    pub chunk_type: ChunkType,
+}
+
+#[derive(StructOpt, Debug, PartialEq)]
+pub struct RemoveArgs {
+    #[structopt(parse(from_os_str), help = "Path to the PNG")]
+    pub file_path: PathBuf,
+    #[structopt(
+            parse(try_from_str = ChunkType::from_str),
+            help = "Chunk type (like 'ruSt')"
+        )]
+    pub chunk_type: ChunkType,
+}
+
+#[derive(StructOpt, Debug, PartialEq)]
+pub struct PrintArgs {
+    #[structopt(parse(from_os_str), help = "Path to the PNG")]
+    pub file_path: PathBuf,
+}
+
 #[derive(Debug, StructOpt, PartialEq)]
 pub enum Subcommand {
     #[structopt(about = "Add a secret message to a PNG")]
-    Encode {
-        #[structopt(parse(from_os_str), help = "Path to the input PNG")]
-        input_file_path: PathBuf,
-        #[structopt(
-            parse(try_from_str = ChunkType::from_str),
-            help = "Chunk type (like 'ruSt')"
-        )]
-        chunk_type: ChunkType,
-        #[structopt(help = "Your secret message")]
-        message: String,
-        #[structopt(parse(from_os_str), help = "Path to the output PNG (optional)")]
-        output_file_path: Option<PathBuf>,
-    },
+    Encode(EncodeArgs),
     #[structopt(about = "Show the secret message in a PNG")]
-    Decode {
-        #[structopt(parse(from_os_str), help = "Path to the PNG")]
-        file_path: PathBuf,
-        #[structopt(
-            parse(try_from_str = ChunkType::from_str),
-            help = "Chunk type (like 'ruSt')"
-        )]
-        chunk_type: ChunkType,
-    },
+    Decode(DecodeArgs),
     #[structopt(about = "Remove a secret message from a PNG")]
-    Remove {
-        #[structopt(parse(from_os_str), help = "Path to the PNG")]
-        file_path: PathBuf,
-        #[structopt(
-            parse(try_from_str = ChunkType::from_str),
-            help = "Chunk type (like 'ruSt')"
-        )]
-        chunk_type: ChunkType,
-    },
+    Remove(RemoveArgs),
     #[structopt(about = "Print every chunk in a PNG")]
-    Print {
-        #[structopt(parse(from_os_str), help = "Path to the PNG")]
-        file_path: PathBuf,
-    },
+    Print(PrintArgs),
 }
 
 mod test {
@@ -67,12 +79,12 @@ mod test {
 
     #[test]
     pub fn test_encode() {
-        let expected = Subcommand::Encode {
+        let expected = Subcommand::Encode(EncodeArgs {
             input_file_path: PathBuf::from("/a/b/c"),
             chunk_type: ChunkType::from_str("RuSt").unwrap(),
             message: "Secret decoder ring".to_string(),
             output_file_path: None,
-        };
+        });
         let cli = Cli::from_iter(vec![
             "pngme",
             "encode",
@@ -87,12 +99,12 @@ mod test {
 
     #[test]
     pub fn test_encode_with_output_file() {
-        let expected = Subcommand::Encode {
+        let expected = Subcommand::Encode(EncodeArgs {
             input_file_path: PathBuf::from("/a/b/c"),
             chunk_type: ChunkType::from_str("RuSt").unwrap(),
             message: "Secret decoder ring".to_string(),
             output_file_path: Some(PathBuf::from("/output/file/path")),
-        };
+        });
         let cli = Cli::from_iter(vec![
             "pngme",
             "encode",
@@ -108,10 +120,10 @@ mod test {
 
     #[test]
     pub fn test_decode() {
-        let expected = Subcommand::Decode {
+        let expected = Subcommand::Decode(DecodeArgs {
             file_path: PathBuf::from("/a/b/c"),
             chunk_type: ChunkType::from_str("PnGm").unwrap(),
-        };
+        });
         let cli = Cli::from_iter(vec!["pngme", "decode", "/a/b/c", "PnGm"]);
         let actual = cli.subcommand;
 
@@ -120,10 +132,10 @@ mod test {
 
     #[test]
     pub fn test_remove() {
-        let expected = Subcommand::Remove {
+        let expected = Subcommand::Remove(RemoveArgs {
             file_path: PathBuf::from("/a/b/c"),
             chunk_type: ChunkType::from_str("imAG").unwrap(),
-        };
+        });
         let cli = Cli::from_iter(vec!["pngme", "remove", "/a/b/c", "imAG"]);
         let actual = cli.subcommand;
 
@@ -132,9 +144,9 @@ mod test {
 
     #[test]
     pub fn test_print() {
-        let expected = Subcommand::Print {
+        let expected = Subcommand::Print(PrintArgs {
             file_path: PathBuf::from("/a/b/c"),
-        };
+        });
         let cli = Cli::from_iter(vec!["pngme", "print", "/a/b/c"]);
         let actual = cli.subcommand;
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,56 +1,56 @@
-use crate::args::Subcommand;
+use crate::args::*;
 use crate::chunk::Chunk;
 use crate::png::Png;
 use std::convert::TryFrom;
 use std::fs;
 
-pub fn run(subcommand: Subcommand) -> crate::Result<()> {
-    match subcommand {
-        Subcommand::Encode {
-            input_file_path,
-            chunk_type,
-            message,
-            output_file_path,
-        } => {
-            let input_bytes = fs::read(&input_file_path)?;
-            let output = output_file_path.unwrap_or(input_file_path);
-            let mut png = Png::try_from(input_bytes.as_slice())?;
-            let chunk = Chunk::new(chunk_type, message.as_bytes().to_vec());
-            png.append_chunk(chunk);
-            fs::write(output, png.as_bytes())?;
-        }
-        Subcommand::Decode {
-            file_path,
-            chunk_type,
-        } => {
-            let input_bytes = fs::read(&file_path)?;
-            let png = Png::try_from(input_bytes.as_slice())?;
-            let chunk = png.chunk_by_type(chunk_type);
-            if let Some(c) = chunk {
-                println!("{}", c);
-            }
-        }
-        Subcommand::Remove {
-            file_path,
-            chunk_type,
-        } => {
-            let input_bytes = fs::read(&file_path)?;
-            let mut png = Png::try_from(input_bytes.as_slice())?;
-            match png.remove_chunk(chunk_type) {
-                Ok(chunk) => {
-                    fs::write(&file_path, png.as_bytes())?;
-                    println!("Removed chunk: {}", chunk);
-                }
-                Err(e) => println!("Error: {}", e),
-            }
-        }
-        Subcommand::Print { file_path } => {
-            let input_bytes = fs::read(&file_path)?;
-            let png = Png::try_from(input_bytes.as_slice())?;
-            for chunk in png.chunks() {
-                println!("{}", chunk);
-            }
-        }
+fn encode(args: EncodeArgs) -> crate::Result<()> {
+    let input_bytes = fs::read(&args.input_file_path)?;
+    let output = args.output_file_path.unwrap_or(args.input_file_path);
+    let mut png = Png::try_from(input_bytes.as_slice())?;
+    let chunk = Chunk::new(args.chunk_type, args.message.as_bytes().to_vec());
+    png.append_chunk(chunk);
+    fs::write(output, png.as_bytes())?;
+    Ok(())
+}
+
+fn decode(args: DecodeArgs) -> crate::Result<()> {
+    let input_bytes = fs::read(&args.file_path)?;
+    let png = Png::try_from(input_bytes.as_slice())?;
+    let chunk = png.chunk_by_type(args.chunk_type);
+    if let Some(c) = chunk {
+        println!("{}", c);
     }
     Ok(())
+}
+
+fn remove(args: RemoveArgs) -> crate::Result<()> {
+    let input_bytes = fs::read(&args.file_path)?;
+    let mut png = Png::try_from(input_bytes.as_slice())?;
+    match png.remove_chunk(args.chunk_type) {
+        Ok(chunk) => {
+            fs::write(&args.file_path, png.as_bytes())?;
+            println!("Removed chunk: {}", chunk);
+        }
+        Err(e) => println!("Error: {}", e),
+    }
+    Ok(())
+}
+
+fn print(args: PrintArgs) -> crate::Result<()> {
+    let input_bytes = fs::read(&args.file_path)?;
+    let png = Png::try_from(input_bytes.as_slice())?;
+    for chunk in png.chunks() {
+        println!("{}", chunk);
+    }
+    Ok(())
+}
+
+pub fn run(subcommand: Subcommand) -> crate::Result<()> {
+    match subcommand {
+        Subcommand::Encode(args) => encode(args),
+        Subcommand::Decode(args) => decode(args),
+        Subcommand::Remove(args) => remove(args),
+        Subcommand::Print(args) => print(args),
+    }
 }


### PR DESCRIPTION
This makes the `match subcommand` block much cleaner.