### PR TITLE
Create a library

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,18 +1,18 @@
-mod args;
+#[doc(inline)]
 mod chunk;
+#[doc(inline)]
 mod chunk_type;
-mod commands;
+#[doc(inline)]
 mod png;
 
-use structopt::StructOpt;
+#[doc(inline)]
+pub use chunk::Chunk;
+#[doc(inline)]
+pub use chunk_type::ChunkType;
+#[doc(inline)]
+pub use png::Png;
 
 /// Holds any kind of error.
 pub type Error = Box<dyn std::error::Error>;
 /// Holds a `Result` of any kind of error.
 pub type Result<T> = std::result::Result<T, Error>;
-
-#[doc(hidden)]
-fn main() -> Result<()> {
-    let cli = args::Cli::from_args();
-    commands::run(cli.subcommand)
-}

--- a/src/png.rs
+++ b/src/png.rs
@@ -5,7 +5,7 @@ use std::error::Error;
 use std::fmt;
 use std::io::{BufReader, Read};
 
-/// A full and valid PNG.
+/// A full and valid PNG composed of Chunks.
 pub struct Png {
     chunks: Vec<Chunk>,
 }


### PR DESCRIPTION
When running `cargo doc`, the `lib.rs` is the documentation entry point, so we can remove some of the `#[doc(hidden)]` that was hiding the CLI-specific code from `main.rs`.